### PR TITLE
FIXIT: blank lines left in XML file

### DIFF
--- a/src/main/java/com/mycompany/app/common/Client.java
+++ b/src/main/java/com/mycompany/app/common/Client.java
@@ -1,5 +1,6 @@
 package com.mycompany.app.common;
 
+import com.mycompany.app.common.XMLFile.XMLWriter;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;

--- a/src/main/java/com/mycompany/app/common/XMLFile/xml-format.xslt
+++ b/src/main/java/com/mycompany/app/common/XMLFile/xml-format.xslt
@@ -1,0 +1,11 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output indent="yes" cdata-section-elements="cdata-other-elements"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/test/java/com/mycompany/app/common/XMLWriterTest.java
+++ b/src/test/java/com/mycompany/app/common/XMLWriterTest.java
@@ -1,7 +1,6 @@
 package com.mycompany.app.common;
 
-import com.mycompany.app.common.Client;
-import com.mycompany.app.common.XMLWriter;
+import com.mycompany.app.common.XMLFile.XMLWriter;
 import com.mycompany.app.common.smokers.SmokerWithMatchstick;
 import com.mycompany.app.common.smokers.SmokerWithPaper;
 import junit.framework.TestCase;


### PR DESCRIPTION
There shouldn't be more blank line every time the motion-trace XML file is updated.